### PR TITLE
Adds trait inside value for closures

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -3,7 +3,7 @@ use crate::ast::{Visitor, Node};
 use crate::value::Value;
 
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Expr {
     Identifier(String),
     Assignment(String, Box<Expr>),

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -1,7 +1,7 @@
 use crate::token::Token;
 use super::expr::Expr;
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Statement {
     Expression(Expr),
     Print(Expr),

--- a/src/callable.rs
+++ b/src/callable.rs
@@ -1,0 +1,24 @@
+use std::fmt;
+use std::cmp;
+
+use crate::value::Value;
+
+use crate::interp::interpreter::{Interpreter, InterpErr};
+
+pub trait Callable {
+    fn call(&self, interp: &mut Interpreter, args: Vec<Value>) -> Result<Value, InterpErr>;
+    fn arity(&self) -> usize;
+}
+
+impl fmt::Debug for Callable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "<no repr for callable>")
+    }
+}
+
+impl PartialEq for Callable {
+    fn eq(&self, _: &Self) -> bool {
+        false
+    }
+}
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod errors;
 mod parser;
 mod interp;
 mod value;
+mod callable;
 
 fn main() {
     env_logger::from_env(Env::default()

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,13 +1,15 @@
+use crate::callable::Callable;
 use std::fmt;
+use std::rc::Rc;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     StringV(String),
     NumberV(f64),
     TrueV,
     FalseV,
     NilV,
-    ClosureV,
+    ClosureV(Rc<Box<Callable>>),
 }
 
 impl fmt::Display for Value {
@@ -18,9 +20,10 @@ impl fmt::Display for Value {
             Value::TrueV => write!(f, "{}", true),
             Value::FalseV => write!(f, "{}", false),
             Value::NilV => write!(f, "Nil", ),
-            Value::ClosureV => write!(f, "ClosureV", ),
+            Value::ClosureV(_) => write!(f, "ClosureV", ),
         }
     }
 }
+
 
 


### PR DESCRIPTION
Note: a lot of compile errors for attempting to simply put a trait inside an
enum field.
The eventual solution was to use an Rc containing a Box, which fixed all of the
compile issues without resorting to lifetiming or using generics, however I
believe that it only "fixes" it because it implements clone stupidly by cloning
the pointer value to the box, so it fixes the Sized issue, along with the
issue with the other traits (cloning, partialeq, etc)